### PR TITLE
Fix auth.py redirect urls to use main blueprint

### DIFF
--- a/BioSync/auth.py
+++ b/BioSync/auth.py
@@ -64,8 +64,7 @@ def login():
         if error is None:
             session.clear()
             session['user_id'] = user['id']
-            return redirect(url_for('index'))
-
+            return redirect(url_for('main.index'))
         flash(error)
 
     return render_template('auth/login.html')
@@ -86,7 +85,7 @@ def load_logged_in_user():
 @bp.route('/logout')
 def logout():
     session.clear()
-    return redirect(url_for('index'))
+    return redirect(url_for('main.index'))
 
 
 def login_required(view):


### PR DESCRIPTION
Fixes BuildError caused by url_for('index') which no longer exists
now that routes are registered under the main blueprint.

Changes made:
- Login redirect updated from url_for('index') to url_for('main.index')
- Logout redirect updated from url_for('index') to url_for('main.index')

Closes #17